### PR TITLE
Fix: Change important variables to camelcase and support bytes

### DIFF
--- a/ipldstore/hamt_wrapper.py
+++ b/ipldstore/hamt_wrapper.py
@@ -181,7 +181,7 @@ class HamtWrapper:
 
         # Register the sha2-256 hash with HAMT
         Hamt.register_hasher(
-            0x12, 32, lambda x: hashlib.sha256(x.encode("utf-8")).digest()
+            0x12, 32, lambda x: hashlib.sha256(x).digest()
         )
         store = HamtMemoryStore()
 
@@ -191,7 +191,7 @@ class HamtWrapper:
         else:
             # Create HAMT from scratch with sensible default options
             self.hamt = Hamt.create(
-                store, options={"bit_width": 8, "bucket_size": 5, "hash_alg": 0x12}
+                store, options={"bitWidth": 8, "bucketSize": 5, "hashAlg": 0x12}
             )
 
         self.others_dict = others_dict if others_dict is not None else {}

--- a/ipldstore/hamt_wrapper.py
+++ b/ipldstore/hamt_wrapper.py
@@ -258,7 +258,7 @@ class HamtWrapper:
             str: key
         """
         yield from self._iter_nested("", self.others_dict)
-        yield from self.hamt.keys()
+        yield from (key.decode("utf-8") for key in self.hamt.keys())
 
     def _iter_nested(self, prefix: str, mapping: dict) -> typing.Iterator[str]:
         """Iterates over all keys in `mapping`, reconstructing the key from decomposed

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     zarr
     psutil
     dask[distributed]
-    py-hamt @ git+ssh://git@github.com/dClimate/py-hamt@v1.0.0
+    py-hamt @ git+ssh://git@github.com/dClimate/py-hamt@v1.1.0
 
 [options.package_data]
 * = py.typed, *.json


### PR DESCRIPTION
Using `bitWidth`, `bucketSize`, and `hashAlg` to allign with the original repo. This will allow cross compatibility. 

Also update the hasher to use type `bytes` instead of type `string` which will also allow cross compatibility.

These two changes will allow schema validation as found here: 

https://github.com/rvagg/js-ipld-hashmap/blob/master/schema-validate.js

Also needed a change on the py-hamt to align there as well:
https://github.com/dClimate/py-hamt/pull/3
