### PR TITLE
kwargs passed to getitems to support more zarr versions

### DIFF
--- a/ipldstore/ipldstore.py
+++ b/ipldstore/ipldstore.py
@@ -39,7 +39,7 @@ class IPLDStore(MutableMappingSB):
         self._store = castore or MappingCAStore()
         if isinstance(self._store, IPFSStore) and should_async_get:
             # Monkey patch zarr to use the async get of multiple chunks
-            def storage_getitems(kv_self, keys, on_error="omit"):
+            def storage_getitems(kv_self, keys, on_error="omit", **kwargs):
                 return kv_self._mutable_mapping.getitems(keys)
 
             import zarr


### PR DESCRIPTION
This PR is required to support later versions of zarr that internally pass additional keyword arguments to `getitems`